### PR TITLE
model ttc routes from trip data

### DIFF
--- a/server/models/nextbus/Stop.js
+++ b/server/models/nextbus/Stop.js
@@ -5,7 +5,8 @@ const Stop = mongoose.model('Stop', {
   title: String, // title of the stop (eg. Queen Street West at Spadina Ave)
   routeTag: String, // tag identifying the route (eg. '504') the stop belongs to
   lon: Number, // longitude of the stop
-  lat: Number, // latitude of the stop
+  lat: Number, // latitude of the stop,
+  endpoint: Number // 0/null for not endpoints, 1 for starting, 2 for terminal
 });
 
 module.exports = Stop;

--- a/server/models/traffic/Path.js
+++ b/server/models/traffic/Path.js
@@ -20,7 +20,11 @@ const pathSchema = new Schema({
   legs: Array, // Array of coordinates [longitudes, latitudes],
   polyline: String,
   lastUpdated: Number,
-  version: String
+  version: String,
+  valid: {
+    type: Boolean,
+    default: true
+  }
 });
 
 const preSaveOrUpdateFn = function (next) {

--- a/server/models/traffic/PathNode.js
+++ b/server/models/traffic/PathNode.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const PathNode = mongoose.model('PathNode', {
+  tag: { type: String, index: true }, // map to transit stop tag
+  title: String,
+  lon: Number,
+  lat: Number,
+  endpoint: Number,
+  children: [{
+    tag: String,
+    routeTags: Array,
+    score: Number, // total duration
+    weight: Number, // number of durations
+    duration: Number, // average duration
+    percent: Number
+  }]
+});
+
+module.exports = PathNode;

--- a/server/models/traffic/PathRoute.js
+++ b/server/models/traffic/PathRoute.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const PathRoute = mongoose.model('PathRoute', {
+  routeTag: String,
+  stops: [{
+    tag: String,
+    title: String,
+    duration: Number
+  }]
+});
+
+module.exports = PathRoute;

--- a/server/scripts/manual/modelPathRoutes.js
+++ b/server/scripts/manual/modelPathRoutes.js
@@ -1,0 +1,249 @@
+const _ = require('lodash');
+const mongoose = require('mongoose');
+
+const bookmark = require('debug')('bookmark');
+const benchmark = require('debug')('benchmark');
+const inspect = require('debug')('inspect');
+
+const Stop = require('../../models/nextbus/Stop');
+const Trip = require('../../models/nextbus/Trip');
+const PathNode = require('../../models/traffic/PathNode');
+const PathRoute = require('../../models/traffic/PathRoute');
+
+const TrafficService = require('../../services/Traffic');
+
+// should accept the following command line arguments:
+// --full    - `true` to re-generate all path nodes and path routes, or `false` to just re-generate path routes
+const yargs = require('yargs/yargs');
+const argv = yargs(process.argv).argv;
+
+mongoose.connect('mongodb://localhost:27017/toronto-traffic', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+});
+
+const populatePathNodes = async () => {
+  bookmark(`(populatePathNodes)`);
+
+  const stopDocs = await Stop.find();
+  for (const stopDoc of stopDocs) {
+    const stop = stopDoc.toJSON();
+    const { tag, title, lon, lat, endpoint } = stop;
+
+    await PathNode.findOneAndUpdate({
+      tag
+    }, {
+      title,
+      lon,
+      lat,
+      endpoint
+    }, {
+      new: true,
+      upsert: true
+    });
+  }
+};
+
+const generatePathNodesChildren = async () => {
+  bookmark(`(generatePathNodesChildren)`);
+
+  const limit = 0;
+  const benchmarkFrequency = (limit)? limit / 10 : 100000;
+
+  const tripQuery = Trip.find().limit(limit);
+  const tripCursor = tripQuery.cursor();
+
+  const pathNodeMap = {};
+
+  const { heapTotal, heapUsed } = process.memoryUsage();
+  inspect(`(generatePathNodesChildren) before tripCursor loop - heapTotal: ${heapTotal}, heapUsed: ${heapUsed}`);
+
+  let count = 1;
+  let tripDoc = await tripCursor.next();
+  while (tripDoc != null) {
+    const routeTag = tripDoc.get('routeTag');
+    const predictionMap = tripDoc.get('predictions') || {};
+    const predictions = _.sortBy(Object.values(predictionMap), ({seconds}) => {
+      return parseInt(seconds);
+    });
+
+    predictions.forEach((current, index) => {
+      if (index >= predictions.length - 1) {
+        return;
+      }
+
+      const currentTag = current.stopTag;
+
+      const next = predictions[index + 1];
+      const nextTag = next.stopTag;
+      const duration = parseInt(next.seconds) - parseInt(current.seconds);
+
+      pathNodeMap[currentTag] = pathNodeMap[currentTag] || {
+        tag: currentTag,
+        totalWeight: 0,
+        childMap: {},
+      };
+      pathNodeMap[currentTag].childMap[nextTag] = pathNodeMap[currentTag].childMap[nextTag] || {
+        tag: nextTag,
+        weight: 0,
+        score: 0,
+        routeTagMap: {}
+      };
+
+      if (duration) {
+        pathNodeMap[currentTag].childMap[nextTag].weight += 1;
+        pathNodeMap[currentTag].childMap[nextTag].score += duration;
+        pathNodeMap[currentTag].childMap[nextTag].routeTagMap[routeTag] = 1;
+        pathNodeMap[currentTag].totalWeight += 1;
+      }
+    });
+
+    tripDoc = await tripCursor.next();
+
+    if (count % benchmarkFrequency === 1) {
+      benchmark(`(generatePathNodesChildren) tripCursor - ${count}`);
+
+      const { heapTotal, heapUsed } = process.memoryUsage();
+      inspect(`(generatePathNodesChildren) tripCursor loop - heapTotal: ${heapTotal}, heapUsed: ${heapUsed}`);
+    }
+    count++;
+  }
+
+  return pathNodeMap;
+};
+
+const populatePathNodesChildren = async (pathNodeMap) => {
+  bookmark(`(populatePathNodesChildren)`);
+
+  for (const { tag, childMap, totalWeight } of Object.values(pathNodeMap)) {
+    let children = Object.values(childMap).map(element => {
+      const { weight, score, routeTagMap } = element;
+      const routeTags = Object.keys(routeTagMap);
+
+      let duration = 0, percent = 0;
+      if (weight && score) {
+        duration = score * 1.0 / weight;
+        percent = weight * 100.0 / totalWeight;
+      }
+
+      if (duration) {
+        return {
+          tag: element.tag,
+          weight,
+          score,
+          duration,
+          percent,
+          routeTags
+        }
+      } else {
+        return null;
+      }
+    });
+
+    children = _.chain(children)
+      .compact()
+      .sortBy('-percent')
+      .value();
+
+    await PathNode.findOneAndUpdate({
+      tag
+    }, {
+      children
+    });
+  }
+};
+
+const sanitizeNode = ({tag, title, endpoint}) => {
+  return {
+    tag,
+    title,
+    endpoint
+  }
+};
+const addToAncestors = (ancestors, node, duration) => {
+  const sanitized = sanitizeNode(node);
+  return [...ancestors, {
+    tag: sanitized.tag,
+    title: sanitized.title,
+    duration
+  }];
+};
+
+const startRouting = async (routeTag) => {
+  bookmark(`(startRouting)`);
+  const pathNodes = await PathNode.find({
+    'children.routeTags': routeTag
+  }).lean();
+
+  const routes = [];
+  const startingNodes = _.filter(pathNodes, {endpoint: 1});
+  for (const startingNode of startingNodes) {
+    const ancestors = addToAncestors([], startingNode, 0);
+    for (const child of startingNode.children) {
+      runRouting(routes, ancestors, pathNodes, child, 0);
+    }
+  }
+
+  return routes;
+};
+
+const runRouting = (result, ancestors, pathNodes, child, level) => {
+  if (child.percent < 5) {
+    return;
+  }
+
+  const childNode = _.find(pathNodes, {
+    tag: child.tag
+  });
+
+  if (!childNode) {
+    result.push([...ancestors]);
+    return;
+  }
+
+  const newAncestors = addToAncestors(ancestors, childNode, child.duration);
+
+  // prevent endless looping
+  if (childNode.endpoint || level >= 100) {
+    result.push(newAncestors)
+    return;
+  }
+
+  for (const grandChild of childNode.children) {
+    runRouting(result, newAncestors, pathNodes, grandChild, level + 1);
+  }
+};
+
+const populateRoutes = async (routeTag, routes, clear) => {
+  bookmark(`(populateRoutes)`);
+
+  if (clear) {
+    await PathRoute.deleteMany({
+      routeTag
+    });
+  }
+
+  for (const route of routes) {
+    if (route.length > 5) { // length of 3 should be sufficient, but just to be safe
+      await PathRoute.create({
+        routeTag,
+        stops: route
+      });
+    }
+  }
+};
+
+(async () => {
+  if (argv.full) {
+    await populatePathNodes();
+    const pathNodeMap = await generatePathNodesChildren();
+    await populatePathNodesChildren(pathNodeMap);
+  }
+
+  const routes = await startRouting('504');
+  await populateRoutes('504', routes, true);
+
+  bookmark(`(return)`);
+})();
+
+// DEBUG=bookmark,benchmark,inspect node scripts/manual/modelPathRoutes.js --full


### PR DESCRIPTION
This is a fix for #4 

The changes here use existing trip data to model actual TTC routes and adjacent stops, which is more desirable than the incomplete route data from Nextbus. The idea is that, when fetching predictions from NextBus, the predictions show a list of stops (not just the immediate one but all subsequent ones up to a limit) and the expected amount of time it would take to arrive at each of those stops. The list is a great source of adjacent stops and their relative duration from each other. By aggregating all those data, it is possible to model a graph structure of the stops and hence the actual routes.

The following steps were taken to make this work:
- **Identify starting and terminal stops**. This is a quick manual step. This makes it easy to traverse the graph from a limited number of points, and ensure the route do not traverse endlessly (eg. the route should stop at terminal stops)
- **Aggregate trip predictions to get adjacent stop data**. For each stop, determine the next stop and the average duration to reach the next stop. Take out outliers but account for splits in the routes. (see PathNode.js)
- **Traverse stops to compute routes**. Start from the starting stops (identified earlier) and traverse the stops until a terminal stop is hit.

The resulting data then are used to validate existing paths:
- For if it is possible to travel from `from` to `to` (and they do not have to be immediately adjacent stops) from any existing routes. For example, if somehow `from` is on a westbound route and `to` is on a eastbound route, then this would not be valid.
- Determine the number of hops and the total duration between `from` and `to`. The current algorithm requires at most 5 hops and a maximum total duration of 10 minutes for the path to be valid. The criteria may be adjusted in the future.
- Check all routes for validity check, or if there is no hit, then the path is invalid too.
- Update validity on all path statuses with matching paths