### PR TITLE
Traffic Layer Refactor and Traffic Interactivity

### DIFF
--- a/client/src/actions/traffic.js
+++ b/client/src/actions/traffic.js
@@ -9,16 +9,7 @@ import {
   SET_TIMELINE_DATA_STATUS
 } from './types';
 import resource from '../resources/traffic';
-
-const TRAFFIC_COLOUR = (score) => {
-  if (score > 3) {
-    return '#F9874E'; // red
-  } else if (score < -3) {
-    return '#8CC788'; // green
-  } else {
-    return '#FAC758'; // yellow
-  }
-};
+import { TrafficToColour } from '../components/common/Util'
 
 const trafficTransformer = (source) => {
   return (timestamps) => {
@@ -43,7 +34,7 @@ const trafficTransformer = (source) => {
 
       const totalWeight = _.sumBy(element.data, 'weight');
       const totalScore = _.sumBy(element.data, 'score');
-      const color = TRAFFIC_COLOUR(totalScore / totalWeight);
+      const color = TrafficToColour(totalScore / totalWeight);
       const x = totalWeight / max;
 
       return {

--- a/client/src/components/common/MapContext.js
+++ b/client/src/components/common/MapContext.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
 const mapContext = React.createContext({
-  value: null
+  map: null,
+  mapAttrs: null
 });
 
 export default mapContext;

--- a/client/src/components/common/Util.js
+++ b/client/src/components/common/Util.js
@@ -2,3 +2,25 @@ export const DATE_FORMAT = 'MMM DD, YYYY';
 export const DATETIME_FORMAT = 'MMM DD, YYYY HH:mm';
 export const TIME_FORMAT = 'HH:mm';
 export const DAY_FORMAT = 'ddd';
+
+export const TRAFFIC_COLOUR_STEPS = [
+  '#8CC788', // green/low traffic
+  0,
+  '#FAC758', // yellow/normal traffic
+  10,
+  '#F9874E', // red/high traffic
+];
+export const TrafficToColour = (score) => {
+  const numSteps = Math.floor(TRAFFIC_COLOUR_STEPS.length / 2);
+
+  for (let i = 0; i < numSteps; i++) {
+    const colour = TRAFFIC_COLOUR_STEPS[i * 2];
+    const step = TRAFFIC_COLOUR_STEPS[i * 2 + 1];
+
+    if (score < step) {
+      return colour;
+    }
+  }
+
+  return TRAFFIC_COLOUR_STEPS[numSteps * 2];
+};

--- a/client/src/components/mapbox/Feature.js
+++ b/client/src/components/mapbox/Feature.js
@@ -1,8 +1,9 @@
 import React, { useContext, useEffect } from 'react';
 import MapContext from '../common/MapContext';
 
-const Feature = ({children, data, id, type}) => {
-  const map = useContext(MapContext);
+const Feature = ({children, data, id, featureId, type}) => {
+  const {map, mapAttrs} = useContext(MapContext);
+
   useEffect(() => {
     return () => {
       if (map && map.getSource(id)) {

--- a/client/src/components/mapbox/Feature.js
+++ b/client/src/components/mapbox/Feature.js
@@ -31,10 +31,10 @@ const Feature = ({children, data, id, featureId, type}) => {
     }
   };
 
-  const createFeature = (type) => {
+  const createFeature = (data, id, featureId, type) => {
     switch (type) {
       case 'LineString':
-        return createLine()
+        return createLine(data, id, featureId)
       case 'FeatureCollection':
         return createCollection();
       default:
@@ -42,7 +42,7 @@ const Feature = ({children, data, id, featureId, type}) => {
     }
   };
 
-  const createLine = () => {
+  const createLine = (data, id, featureId) => {
     return {
       type: 'Feature',
       properties: {
@@ -63,7 +63,7 @@ const Feature = ({children, data, id, featureId, type}) => {
     };
 
     React.Children.forEach(children, (child) => {
-      const feature = createFeature(child.props.data, child.props.id, child.props.type);
+      const feature = createFeature(child.props.data, child.props.id, child.props.featureId, child.props.type);
       if (feature) {
         sourceData.features.push(feature);
       }
@@ -72,7 +72,7 @@ const Feature = ({children, data, id, featureId, type}) => {
     return sourceData;
   };
 
-  const sourceData = createFeature(type);
+  const sourceData = createFeature(data, id, featureId, type);
   addOrUpdateSource(id, sourceData);
 
   return null;

--- a/client/src/components/mapbox/Feature.js
+++ b/client/src/components/mapbox/Feature.js
@@ -30,10 +30,10 @@ const Feature = ({children, data, id, type}) => {
     }
   };
 
-  const createFeature = (data, id, type) => {
+  const createFeature = (type) => {
     switch (type) {
       case 'LineString':
-        return createLine(data, id)
+        return createLine()
       case 'FeatureCollection':
         return createCollection();
       default:
@@ -41,7 +41,7 @@ const Feature = ({children, data, id, type}) => {
     }
   };
 
-  const createLine = (data, id) => {
+  const createLine = () => {
     return {
       type: 'Feature',
       properties: {
@@ -50,7 +50,8 @@ const Feature = ({children, data, id, type}) => {
       geometry: {
         type: 'LineString',
         coordinates: data.legs || []
-      }
+      },
+      id: featureId
     };
   };
 
@@ -70,7 +71,7 @@ const Feature = ({children, data, id, type}) => {
     return sourceData;
   };
 
-  const sourceData = createFeature(data, id, type);
+  const sourceData = createFeature(type);
   addOrUpdateSource(id, sourceData);
 
   return null;

--- a/client/src/components/mapbox/Feature.js
+++ b/client/src/components/mapbox/Feature.js
@@ -35,7 +35,7 @@ const Feature = ({children, data, id, type}) => {
       case 'LineString':
         return createLine(data, id)
       case 'FeatureCollection':
-        return createCollection(data, id, type);
+        return createCollection();
       default:
         return null;
     }
@@ -54,7 +54,7 @@ const Feature = ({children, data, id, type}) => {
     };
   };
 
-  const createCollection = (data, id) => {
+  const createCollection = () => {
     const sourceData = {
       type: 'FeatureCollection',
       features: []
@@ -66,8 +66,6 @@ const Feature = ({children, data, id, type}) => {
         sourceData.features.push(feature);
       }
     });
-
-    console.log(sourceData);
 
     return sourceData;
   };

--- a/client/src/components/mapbox/Layer.js
+++ b/client/src/components/mapbox/Layer.js
@@ -12,7 +12,8 @@ const getTypeData = (type, data) => {
         type: 'line',
         layout: {
           'line-join': 'round',
-          'line-cap': 'round'
+          'line-cap': 'round',
+          'line-round-limit': 2
         },
         paint: {
           'line-color': 'white',

--- a/client/src/components/mapbox/Layer.js
+++ b/client/src/components/mapbox/Layer.js
@@ -48,7 +48,6 @@ const Layer = ({children, data, id, type, source, onClick, onMousemove, onMousel
 
   const addOrUpdateLayer = (id, layer) => {
     const existingLayer = map.getLayer(id);
-
     if (existingLayer) {
       map.setPaintProperty(id, 'line-color', layer.paint['line-color']);
     } else {

--- a/client/src/components/mapbox/Layer.js
+++ b/client/src/components/mapbox/Layer.js
@@ -46,7 +46,7 @@ const Layer = ({children, data, id, type, source, onClick, onMousemove, onMousel
     };
   }, []);
 
-  const addOrUpdateLayer = (id, layer) => {
+  const addOrUpdateLayer = (id, layer, source) => {
     const existingLayer = map.getLayer(id);
     if (existingLayer) {
       map.setPaintProperty(id, 'line-color', layer.paint['line-color']);
@@ -58,7 +58,7 @@ const Layer = ({children, data, id, type, source, onClick, onMousemove, onMousel
       }
 
       const customEventData = {
-        sourceId: id,
+        sourceId: source,
         map,
         mapAttrs
       };
@@ -94,7 +94,7 @@ const Layer = ({children, data, id, type, source, onClick, onMousemove, onMousel
       }
     });
 
-    addOrUpdateLayer(id, layer);
+    addOrUpdateLayer(id, layer, source);
   }
 
   return null;

--- a/client/src/components/mapbox/Layer.js
+++ b/client/src/components/mapbox/Layer.js
@@ -35,8 +35,8 @@ const getTypeData = (type, data) => {
   return typeData;
 };
 
-const Layer = ({children, data, id, type, source, onClick}) => {
-  const map = useContext(MapContext);
+const Layer = ({children, data, id, type, source, onClick, onMousemove, onMouseleave}) => {
+  const {map, mapAttrs} = useContext(MapContext);
 
   useEffect(() => {
     return () => {
@@ -57,6 +57,21 @@ const Layer = ({children, data, id, type, source, onClick}) => {
       if (onClick) {
         map.on('click', id, onClick);
       }
+
+      const customEventData = {
+        sourceId: id,
+        map,
+        mapAttrs
+      };
+
+      if (onMousemove) {
+        map.on('mousemove', id, (e) => onMousemove(e, customEventData));
+      }
+
+      if (onMouseleave) {
+        map.on('mouseleave', id, (e) => onMouseleave(e, customEventData));
+      }
+
     }
   };
 

--- a/client/src/components/mapbox/MapMetadata.js
+++ b/client/src/components/mapbox/MapMetadata.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useContext } from 'react';
 import MapContext from '../common/MapContext';
 
 const Metadata = () => {
-  const map = useContext(MapContext);
+  const {map} = useContext(MapContext);
 
   const [lng, setLng] = useState(0);
   const [lat, setLat] = useState(0);

--- a/client/src/components/mapbox/Mapbox.js
+++ b/client/src/components/mapbox/Mapbox.js
@@ -25,17 +25,19 @@ const Mapbox = ({ children }) => {
       style: 'mapbox://styles/mapbox/dark-v10',
       // center: [DEFAULT.lng, DEFAULT.lat],
       // zoom: DEFAULT.zoom,
-      bounds: DEFAULT.bounds
+      bounds: DEFAULT.bounds,
     });
     setMap(mapInstance);
 
     mapInstance.on('load', () => {
       setReady(true);
-    });
 
-    mapInstance.on('moveend', (e) => {
-      console.log(mapInstance.getCenter());
-      console.log(mapInstance.getZoom());
+      // A hack to disabled touchscreen tap-and-drag zoom behaviour introduced
+      // in Mapbox GL JS v2. The default timing (ie. time between taps) is
+      // too long and introduced unintentional tap behaviour and there is no
+      // way to change the timing or only disabled tag-and-drag throuhg the
+      // official API.
+      mapInstance.touchZoomRotate._tapDragZoom._enabled = false;
     });
 
     return () => {

--- a/client/src/components/mapbox/Mapbox.js
+++ b/client/src/components/mapbox/Mapbox.js
@@ -53,8 +53,13 @@ const Mapbox = ({ children }) => {
     });
   };
 
+  const mapContextValue = {
+    map: map,
+    mapAttrs: {}
+  };
+
   return (
-    <MapContext.Provider value={map}>
+    <MapContext.Provider value={mapContextValue}>
       <div className="map">
         <div className="map-container absolute inset-0 z-0" ref={mapContainer}>
           { renderChildren() }

--- a/client/src/components/route/SubrouteMap.js
+++ b/client/src/components/route/SubrouteMap.js
@@ -13,7 +13,12 @@ const SubrouteMap = () => {
 
   const layerData = {
     lineColor: "#222222",
-    lineWidth: 5,
+    // lineWidth: 5,
+    lineWidth: [
+      'interpolate', ['linear'], ['zoom'],
+      12, 1,
+      14, 5
+    ],
     lineOffset: 5
   };
 

--- a/client/src/components/route/SubrouteMap.js
+++ b/client/src/components/route/SubrouteMap.js
@@ -19,7 +19,7 @@ const SubrouteMap = () => {
       12, 1,
       14, 5
     ],
-    lineOffset: 5
+    lineOffset: 6
   };
 
   return (

--- a/client/src/components/traffic/TrafficMap.js
+++ b/client/src/components/traffic/TrafficMap.js
@@ -1,16 +1,14 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+
 import Layer from '../mapbox/Layer';
 import Feature from '../mapbox/Feature';
+import { TRAFFIC_COLOUR_STEPS } from '../common/Util';
 
 const LAYER_DATA = {
   lineColor: [
     'step', ['get', 'average'],
-    '#8CC788', // green/low traffic
-    -10,
-    '#FAC758', // yellow/normal traffic
-    10,
-    '#F9874E', // red/high traffic
+    ...TRAFFIC_COLOUR_STEPS
   ],
   lineWidth: [
     'interpolate', ['linear'], ['zoom'],
@@ -27,11 +25,7 @@ const HITBOX_LAYER_DATA = {
 const HIGHLIGHT_LAYER_DATA = {
   lineColor: [
     'step', ['get', 'average'],
-    '#8CC788',
-    -10,
-    '#FAC758',
-    10,
-    '#F9874E'
+    ...TRAFFIC_COLOUR_STEPS
   ],
   lineWidth: [
     'case',

--- a/client/src/components/traffic/TrafficMap.js
+++ b/client/src/components/traffic/TrafficMap.js
@@ -108,6 +108,7 @@ const TrafficMap = () => {
     return Object.keys(pathMap).map((pathId) => {
       const { layerData, sourceData, featureId } = pathMap[pathId];
       return (
+        <Layer type="line" data={layerData} id={pathId} source={pathId} key={pathId} onClick={onPathClicked} onMousemove={onPathMousemove} onMouseleave={onPathMouseleave}>
           <Feature data={sourceData} id={pathId} featureId={featureId} type="LineString"/>
         </Layer>
       )
@@ -132,6 +133,34 @@ const TrafficMap = () => {
 
     console.log(e);
     console.log(e.features[0].properties);
+  };
+
+  const onPathMousemove = (e, data) => {
+    const { map, mapAttrs, sourceId } = data;
+    map.getCanvas().style.cursor = 'pointer';
+
+    if (e.features.length > 0) {
+      mapAttrs.hoverStateId = e.features[0].id;
+
+      map.setFeatureState(
+        { source: sourceId, id: mapAttrs.hoverStateId },
+        { hover: true }
+      );
+    }
+  };
+  const onPathMouseleave = (e, data) => {
+    const { map, mapAttrs, sourceId } = data;
+    const { hoverStateId } = mapAttrs;
+    map.getCanvas().style.cursor = '';
+
+    if (hoverStateId) {
+      map.setFeatureState(
+        { source: sourceId, id: hoverStateId },
+        { hover: false }
+      );
+
+      mapAttrs.hoverStateId = null;
+    }
   };
 
   if (!Number.isInteger(selectedTime)) {

--- a/client/src/components/traffic/TrafficMap.js
+++ b/client/src/components/traffic/TrafficMap.js
@@ -13,6 +13,15 @@ const TRAFFIC_COLOUR = (score) => {
   }
 };
 
+let numberId = 1;
+const pathToNumberIdMap = {};
+const getNumberIdFromPath = (from, to) => {
+  const identifier = `${from}_${to}`;
+  pathToNumberIdMap[identifier] = pathToNumberIdMap[identifier] || numberId++;
+
+  return pathToNumberIdMap[identifier];
+};
+
 const TrafficMap = () => {
   const trafficByTimestamp = useSelector(store => store.traffic.trafficByTimestamp);
   const selectedTime = useSelector(store => store.timeline.selected);
@@ -61,9 +70,11 @@ const TrafficMap = () => {
         };
 
         const pathId = `${datum.path.from}_${datum.path.to}`;
+        const featureId = getNumberIdFromPath(datum.path.from, datum.path.to); // Mapbox feature id has to be numerical
         pathMap[pathId] = pathMap[pathId] || {
           layerData,
-          sourceData
+          sourceData,
+          featureId
         };
 
         pathMap[pathId].layerData = {
@@ -74,6 +85,12 @@ const TrafficMap = () => {
             'interpolate', ['linear'], ['zoom'],
             12, 0.5,
             14, 3
+          ],
+          lineWidth: [
+            'case',
+            ['boolean', ['feature-state', 'hover'], false],
+            6,
+            3
           ],
           lineOffset: 5,
           opacity
@@ -89,10 +106,9 @@ const TrafficMap = () => {
   const renderTrafficPaths = () => {
     const pathMap = pathMapRef.current;
     return Object.keys(pathMap).map((pathId) => {
-      const { layerData, sourceData } = pathMap[pathId];
+      const { layerData, sourceData, featureId } = pathMap[pathId];
       return (
-        <Layer type="line" data={layerData} id={pathId} source={pathId} key={pathId} onClick={onPathClicked}>
-          <Feature data={sourceData} id={pathId} type="LineString"/>
+          <Feature data={sourceData} id={pathId} featureId={featureId} type="LineString"/>
         </Layer>
       )
     });

--- a/client/src/components/traffic/TrafficMap.js
+++ b/client/src/components/traffic/TrafficMap.js
@@ -55,6 +55,7 @@ const TrafficMap = () => {
             from: datum.path.from,
             to: datum.path.to,
             timestamp: snapshot.timestamp,
+            average: average,
             legs
           }
         };
@@ -63,12 +64,17 @@ const TrafficMap = () => {
         pathMap[pathId] = pathMap[pathId] || {
           layerData,
           sourceData
-        }
+        };
 
         pathMap[pathId].layerData = {
           ...layerData,
           lineColor: colour,
-          lineWidth: 3,
+          // lineWidth: 3,
+          lineWidth: [
+            'interpolate', ['linear'], ['zoom'],
+            12, 0.5,
+            14, 3
+          ],
           lineOffset: 5,
           opacity
         };

--- a/client/src/components/traffic/TrafficMap.js
+++ b/client/src/components/traffic/TrafficMap.js
@@ -126,22 +126,35 @@ const TrafficMap = () => {
         12, 0.5,
         14, 3
       ],
-      /* lineWidth: [
-        'case',
-        ['boolean', ['feature-state', 'hover'], false],
-        6,
-        3
-      ], */
-      lineOffset: 5,
+      lineOffset: 10,
     };
     const layerId = `path-lines-${selectedTime}`;
 
     const hitboxLayerData = {
-      lineColor: 'rgba(255, 255, 255, 0.5)',
-      lineWidth: 5,
-      lineOffset: 5
+      lineColor: 'transparent',
+      lineWidth: 20,
+      lineOffset: 15
     };
-    const hitboxLayerId = `path-hitbox-${selectedTime}`;
+    const hitboxLayerId = `path-hitboxes-${selectedTime}`;
+
+    const highlightLayerData = {
+      lineColor: [
+        'step', ['get', 'average'],
+        '#8CC788',
+        -10,
+        '#FAC758',
+        10,
+        '#F9874E'
+      ],
+      lineWidth: [
+        'case',
+        ['boolean', ['feature-state', 'hover'], false],
+        10,
+        0
+      ],
+      lineOffset: 10
+    };
+    const highlightLayerId = `path-highlights-${selectedTime}`;
 
     const sourceId = `paths-${selectedTime}`;
 
@@ -163,9 +176,13 @@ const TrafficMap = () => {
           id={layerId}
           source={sourceId}
           key={layerId}
-          onClick={onPathClicked}
-          onMousemove={onPathMousemove}
-          onMouseleave={onPathMouseleave}
+        />
+        <Layer
+          type="line"
+          data={highlightLayerData}
+          id={highlightLayerId}
+          source={sourceId}
+          key={highlightLayerId}
         />
         <Layer
           type="line"
@@ -182,31 +199,31 @@ const TrafficMap = () => {
   };
 
   const onPathClicked = (e) => {
-    /* var coordinates = e.features[0].geometry.coordinates.slice();
-    var description = e.features[0].properties.description;
-
-    // Ensure that if the map is zoomed out such that multiple
-    // copies of the feature are visible, the popup appears
-    // over the copy being pointed to.
-    while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
-      coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
-    }
-
-    new mapboxgl.Popup()
-      .setLngLat(coordinates)
-      .setHTML(description)
-      .addTo(map); */
-
     console.log(e);
     console.log(e.features[0].properties);
   };
 
   const onPathMousemove = (e, data) => {
-    const { map, mapAttrs, sourceId } = data;
+    const { map, mapAttrs } = data;
     map.getCanvas().style.cursor = 'pointer';
+
+    const { hoverStateId } = mapAttrs;
+    if (hoverStateId) {
+      const sourceId = `paths-${selectedTime}`;
+
+      map.setFeatureState(
+        { source: sourceId, id: hoverStateId },
+        { hover: false }
+      );
+
+      mapAttrs.hoverStateId = null;
+    }
+
 
     if (e.features.length > 0) {
       mapAttrs.hoverStateId = e.features[0].id;
+      console.log(`e.features[0].id: ${e.features[0].id}`);
+      const sourceId = `paths-${selectedTime}`;
 
       map.setFeatureState(
         { source: sourceId, id: mapAttrs.hoverStateId },
@@ -215,11 +232,13 @@ const TrafficMap = () => {
     }
   };
   const onPathMouseleave = (e, data) => {
-    const { map, mapAttrs, sourceId } = data;
+    const { map, mapAttrs } = data;
     const { hoverStateId } = mapAttrs;
     map.getCanvas().style.cursor = '';
 
     if (hoverStateId) {
+      const sourceId = `paths-${selectedTime}`;
+
       map.setFeatureState(
         { source: sourceId, id: hoverStateId },
         { hover: false }


### PR DESCRIPTION
**Problem**

- It is really difficult to precisely click on a polyline feature because of the small hitbox
- Previously each traffic path had its own layer. The 504 King route can consist of around 100 traffic path layers. This was because of the understanding that each layer can accept only 1 line colour and it was necessary to separate all paths so that each path can have its own line colour.

**Research**
Turns out these two problems are related.

- **Hitbox Layer Technique**: To solve the problem of the hitbox of a polyline, some research suggested to add a transparent polyline layer on top of the original polyline layer. The transparent polyene would have increased line width and hence bigger hitbox.
- **Layer and Performance**: But this solution would have added 100 more path layers, which seemed too brute-force. Some research suggested that having too many layers can also cause performance degradation.
- **Line Style Expression**: Turns out it is possible to apply an "expression" to many line styles including line colours. For example, apply a step "expression" to have multiple line colours outputs depending on the source value input.

**Solution**
To solve the problems, we need to do the following in order:
- group all traffic paths into one "paths" source that will be the source of all path layers
- base "traffic paths" layer that display the traffic status along the transit route
- "traffic hitboxes" layer that act as the hitbox for each corresponding path, by using wider but transparent lines
- "traffic highlights" layer that displayed highlighted path on top of the original; this is preferred over applying highlighted style directly on the base layer because the base layer already has an expression for the lineColor and cannot accept a nested expression for the highlighted state. 