### PR TITLE
[Hotfix] Handle Route Changes

### DIFF
--- a/server/models/nextbus/Stop.js
+++ b/server/models/nextbus/Stop.js
@@ -6,7 +6,8 @@ const Stop = mongoose.model('Stop', {
   routeTag: String, // tag identifying the route (eg. '504') the stop belongs to
   lon: Number, // longitude of the stop
   lat: Number, // latitude of the stop,
-  endpoint: Number // 0/null for not endpoints, 1 for starting, 2 for terminal
+  endpoint: Number, // 0/null for not endpoints, 1 for starting, 2 for terminal,
+  enabled: Boolean
 });
 
 module.exports = Stop;

--- a/server/scripts/nextbus/fetchData.js
+++ b/server/scripts/nextbus/fetchData.js
@@ -12,7 +12,7 @@ const fetchTrips = require('./parts/fetchTrips');
 const jobs = [{
   name: fetchRoute.name,
   fetch: fetchRoute.fetch,
-  interval: '1 day',
+  interval: '15 minutes',
   active: true,
   params: {
     routeTag: 504
@@ -54,9 +54,17 @@ const run = async () => {
       await agenda.every(interval, name, params);
     }
   }
+};
+
+const graceful = async () => {
+  await agenda.stop();
+  process.exit(0);
 }
 
 (async () => {
+  process.on('SIGTERM', graceful);
+  process.on('SIGINT' , graceful);
+
   await initialize();
   await run();
 })();

--- a/server/scripts/nextbus/parts/fetchRoute.js
+++ b/server/scripts/nextbus/parts/fetchRoute.js
@@ -11,12 +11,17 @@ const fetchRoute = async (job) => {
 
   const { stops, directions } = await NextbusService.fetchRoute(routeTag);
 
+  await Stop.updateMany({ routeTag }, { $set: { enabled: false } });
+
   for (const stop of stops) {
     const filter = {
       tag: stop.tag
     };
 
-    await Stop.findOneAndUpdate(filter, stop, {
+    await Stop.findOneAndUpdate(filter, {
+      ...stop,
+      enabled: true
+    }, {
       new: true,
       upsert: true
     });

--- a/server/scripts/nextbus/parts/fetchTrips.js
+++ b/server/scripts/nextbus/parts/fetchTrips.js
@@ -9,7 +9,8 @@ const getCurrentTimestamp = () => {
 
 const findRouteStops = async (routeTag) => {
   const stops = await Stop.find({
-    routeTag
+    routeTag,
+    enabled: true
   });
 
   return stops;


### PR DESCRIPTION
**Problem**
The predictions suddenly stopped on January 3, 2021.

**Cause**
Upon a quick inspection, it looks like there were changes to active streetcar stops. Some previously active streetcar stops are no longer active (based on quick test with Nextbus API). Because when retrieving prediction data, the request must ask for predictions for each stops (rather than simply asking the API to return all predictions for each route), the request is now asking for data from inactive stops, causing the API to return an error message.

Not sure if the changes are permanent/seasonal/temporary, because there is not indication of changes based on TTC service change announcement.

**Solution**
Because we can only retrieve prediction data in real-time, we must come out with a quick fix to reduce down time to mitigate gaps in the data. The following quick fix involves:

- Add `enabled` attribute to stop
- The job that fetches the active stops (eg. `FETCH_ROUTE`) will now use the `enabled` attribute to mark whether the stops are active or not. Inactive stops are not deleted from the database.
- `FETCH_ROUTE` will now also run every 15 minutes instead of once a day, in case there is a sudden change to active stops.
- The job that fetches the real-time predictions (eg. `FETCH_TRIPS`) will now only fetch predictions from active stops

Now, in the case there is a sudden change to active stops, the system will still miss some data. However, the disruption should last no more than 15 minutes when the background job picks up the new active stops.

**Future Solution**
One possible solution is that `FETCH_TRIPS` can simply check for active stops right before querying for predictions. However, this will double the number of requests to Nextbus API and we will want to save some rate limit (albeit arbitrary rate limit since Nextbus doesn't impose one) for future routes. We are also not expecting frequent changes to the active stops. So for now we will not explore this solution.