### PR TITLE
Fix additional bug when unselect path after time change

### DIFF
--- a/client/src/components/traffic/TrafficMap.js
+++ b/client/src/components/traffic/TrafficMap.js
@@ -40,7 +40,7 @@ const TrafficMap = () => {
           { select: true }
         );
 
-        mapAttrs.selectSourceId = e.sourceId;
+        mapAttrs.selectData.sourceId = e.sourceId;
       }
 
       map.off('sourcedata', onMapSourceData);
@@ -188,6 +188,8 @@ const TrafficMap = () => {
         { select: true }
       );
 
+      console.log('onPathClicked', sourceId, mapAttrs.selectData.featureId);
+
       const onPathSelectionReset = () => {
         unselectCurrent(map, mapAttrs);
       };
@@ -207,6 +209,7 @@ const TrafficMap = () => {
     if (e.features.length > 0) {
       const sourceId = GenerateId.pathSourceId(selectedTime);
       mapAttrs.hoverData = {
+        sourceId,
         featureId: e.features[0].id
       };
 
@@ -237,11 +240,10 @@ const TrafficMap = () => {
     }
   };
   const unhoverCurrent = (map, mapAttrs) => {
-    const sourceId = GenerateId.pathSourceId(selectedTime);
     const hoverData = mapAttrs.hoverData || {};
-    const { featureId } = hoverData;
+    const { featureId, sourceId } = hoverData;
 
-    if (featureId) {
+    if (featureId && sourceId) {
       map.setFeatureState(
         { source: sourceId, id: featureId },
         { hover: false }

--- a/client/src/components/traffic/TrafficMap.js
+++ b/client/src/components/traffic/TrafficMap.js
@@ -188,8 +188,6 @@ const TrafficMap = () => {
         { select: true }
       );
 
-      console.log('onPathClicked', sourceId, mapAttrs.selectData.featureId);
-
       const onPathSelectionReset = () => {
         unselectCurrent(map, mapAttrs);
       };


### PR DESCRIPTION
**Problem**
There is another bug when unselecting a path if the currently displayed time has changed since the user selects the path.

**Cause**
To indicate whether a path is being selected or unselected on the Mapbox map, the code must set:
- id: numerical id of the individual feature that is being selected/unselected (ie. path)
- source: id of the source the individual feature belongs to (eg. this is time-dependent in the code)

Previously, a feature was added to allow a selected path to remain selected even when the user changes the currently displayed time. The change involves updating the source id, which is the time-dependent part of the data.

However, an earlier refactor updates the source id to the wrong field.

**Fix**
Ensure the source id is updated properly